### PR TITLE
added return type for getProvideArgs function

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
 import { InjectionProvide } from './types';
 import Injector from './injector';
 import { injectorKey } from './context';
+import { InjectionKey } from 'vue';
 
-export const getProvideArgs = (providers: InjectionProvide[], name = '') => {
+export const getProvideArgs = (providers: InjectionProvide[], name = ''): [InjectionKey<Injector>, Injector] => {
   const injector = new Injector(providers, { name });
   return [injectorKey, injector];
 };


### PR DESCRIPTION
I got a typescript error when trying to use `app.provide(...getProvideArgs([MyStore], 'app'));` as described in the readme.

Adding the return types corrects the error
